### PR TITLE
ci(dependabot): disable major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      
+    ignore:
+      - dependency-name: "*" 
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Major dependency updates can disrupt our workflows and/or introduce unpredictable issues downstream. They should be done deliberately and carefully.

Automatic updates should be fine for minor and patch updates.