### PR TITLE
Fix class method definition for "human_#{collection_name}"

### DIFF
--- a/lib/human_enum.rb
+++ b/lib/human_enum.rb
@@ -49,7 +49,7 @@ module HumanEnum
 
   class_methods do # rubocop:disable Metrics/BlockLength
     def enum(...)
-      super(...).tap { humanize_enums }
+      super.tap { humanize_enums }
     end
 
     # DEPRECATED: This method is deprecated and will be removed in future versions.
@@ -104,7 +104,7 @@ module HumanEnum
       collection_name = enum_name.to_s.pluralize
       return if respond_to?(:"human_#{collection_name}")
 
-      self.class.send :define_method, "human_#{collection_name}" do
+      define_singleton_method :"human_#{collection_name}" do
         values.to_h { |key, _| [key.to_sym, _translate_enum(enum_name, key)] }
       end
     end

--- a/spec/human_enum_spec.rb
+++ b/spec/human_enum_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe HumanEnum do
         include_examples 'translations', :direction,
                          north: 'Up?', south: 'South', east: 'East', west: 'West'
       end
+
+      context 'with multiple models using the same enum name' do
+        include_examples 'multiple models'
+      end
     end
   end
 end

--- a/spec/human_enum_spec.rb
+++ b/spec/human_enum_spec.rb
@@ -35,9 +35,10 @@ RSpec.describe HumanEnum do
                          north: 'Up?', south: 'South', east: 'East', west: 'West'
       end
 
-      context 'with multiple models using the same enum name' do
-        include_examples 'multiple models'
-      end
+      it_behaves_like 'multiple models using the same enum name',
+                      :status,
+                      { active: 'First Active', inactive: 'First Inactive' },
+                      { pending: 'Second Pending', completed: 'Second Completed' }
     end
   end
 end

--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -16,5 +16,13 @@ RSpec.configure do |_config|
       t.string 'shape'
       t.string 'direction'
     end
+
+    create_table 'first_models' do |t|
+      t.integer 'status'
+    end
+
+    create_table 'second_models' do |t|
+      t.integer 'status'
+    end
   end
 end

--- a/spec/support/locales/en.yml
+++ b/spec/support/locales/en.yml
@@ -11,3 +11,11 @@ en:
         colors:
           red: "Red"
           blue: "Violets are blue"
+      multiple/first_model:
+        statuses:
+          active: "First Active"
+          inactive: "First Inactive"
+      multiple/second_model:
+        statuses:
+          pending: "Second Pending"
+          completed: "Second Completed"

--- a/spec/support/models/multiple.rb
+++ b/spec/support/models/multiple.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Multiple
+  class FirstModel < ActiveRecord::Base
+    include HumanEnum
+    enum :status, { active: 0, inactive: 1 }
+  end
+
+  class SecondModel < ActiveRecord::Base
+    include HumanEnum
+    enum :status, { pending: 0, completed: 1 }
+  end
+end

--- a/spec/support/shared/multiple_model_examples.rb
+++ b/spec/support/shared/multiple_model_examples.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'multiple models' do
+  let(:enum_name) { :status }
+  let(:plural_enum_name) { enum_name.to_s.pluralize }
+  let(:first_model_values) { { active: 'First Active', inactive: 'First Inactive' } }
+  let(:second_model_values) { { pending: 'Second Pending', completed: 'Second Completed' } }
+
+  before do
+    # Define test models
+    stub_const('FirstModel', Class.new(ActiveRecord::Base) do
+      include HumanEnum
+      enum :status, { active: 0, inactive: 1 }
+    end)
+    stub_const('SecondModel', Class.new(ActiveRecord::Base) do
+      include HumanEnum
+      enum :status, { pending: 0, completed: 1 }
+    end)
+
+    # Setup FirstModel translations
+    first_model_values.each do |key, value|
+      allow(I18n).to receive(:t)
+        .with(:"activerecord.attributes.first_model.#{plural_enum_name}.#{key}", any_args)
+        .and_return(value)
+    end
+
+    # Setup SecondModel translations
+    second_model_values.each do |key, value|
+      allow(I18n).to receive(:t)
+        .with(:"activerecord.attributes.second_model.#{plural_enum_name}.#{key}", any_args)
+        .and_return(value)
+    end
+  end
+
+  it "FirstModel has its own human_\#{plural_enum_name} method with correct translations" do
+    expect(FirstModel.public_send(:"human_#{plural_enum_name}")).to eq(first_model_values)
+  end
+
+  it "SecondModel has its own human_\#{plural_enum_name} method with correct translations" do
+    expect(SecondModel.public_send(:"human_#{plural_enum_name}")).to eq(second_model_values)
+  end
+
+  it "models have different human_\#{plural_enum_name} results" do
+    expect(FirstModel.public_send(:"human_#{plural_enum_name}"))
+      .not_to eq(SecondModel.public_send(:"human_#{plural_enum_name}"))
+  end
+end

--- a/spec/support/shared/multiple_model_examples.rb
+++ b/spec/support/shared/multiple_model_examples.rb
@@ -1,47 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'multiple models' do
-  let(:enum_name) { :status }
+RSpec.shared_examples 'multiple models using the same enum name' do |enum_name, first_model_values, second_model_values|
   let(:plural_enum_name) { enum_name.to_s.pluralize }
-  let(:first_model_values) { { active: 'First Active', inactive: 'First Inactive' } }
-  let(:second_model_values) { { pending: 'Second Pending', completed: 'Second Completed' } }
 
-  before do
-    # Define test models
-    stub_const('FirstModel', Class.new(ActiveRecord::Base) do
-      include HumanEnum
-      enum :status, { active: 0, inactive: 1 }
-    end)
-    stub_const('SecondModel', Class.new(ActiveRecord::Base) do
-      include HumanEnum
-      enum :status, { pending: 0, completed: 1 }
-    end)
+  describe Multiple::FirstModel do
+    subject { described_class.public_send(:"human_#{plural_enum_name}") }
 
-    # Setup FirstModel translations
-    first_model_values.each do |key, value|
-      allow(I18n).to receive(:t)
-        .with(:"activerecord.attributes.first_model.#{plural_enum_name}.#{key}", any_args)
-        .and_return(value)
-    end
-
-    # Setup SecondModel translations
-    second_model_values.each do |key, value|
-      allow(I18n).to receive(:t)
-        .with(:"activerecord.attributes.second_model.#{plural_enum_name}.#{key}", any_args)
-        .and_return(value)
-    end
+    it { is_expected.to eq first_model_values }
+    it { is_expected.not_to eq second_model_values }
   end
 
-  it "FirstModel has its own human_\#{plural_enum_name} method with correct translations" do
-    expect(FirstModel.public_send(:"human_#{plural_enum_name}")).to eq(first_model_values)
-  end
+  describe Multiple::SecondModel do
+    subject { described_class.public_send(:"human_#{plural_enum_name}") }
 
-  it "SecondModel has its own human_\#{plural_enum_name} method with correct translations" do
-    expect(SecondModel.public_send(:"human_#{plural_enum_name}")).to eq(second_model_values)
-  end
-
-  it "models have different human_\#{plural_enum_name} results" do
-    expect(FirstModel.public_send(:"human_#{plural_enum_name}"))
-      .not_to eq(SecondModel.public_send(:"human_#{plural_enum_name}"))
+    it { is_expected.to eq second_model_values }
+    it { is_expected.not_to eq first_model_values }
   end
 end


### PR DESCRIPTION
## Problem Description

When including `HumanEnum` in `ApplicationRecord` (or any base class that multiple models inherit from), all models share the same `human_#{collection_name}` class methods, causing unexpected behavior. For example, if both `User` and `Article` models define an enum with the same name (e.g., `status`), calling `User.human_statuses` and `Article.human_statuses` would return the same result, even though they should have different translations.

## Root Cause

The issue is in the `_define_class_method` method of `HumanEnum`:

```ruby
def _define_class_method(enum_name, values)
  ...

  self.class.send :define_method, "human_#{collection_name}" do
    values.to_h { |key, _| [key.to_sym, _translate_enum(enum_name, key)] }
  end
end
```

The problem is that `self.class.send :define_method` defines the method on the base class itself, not on the model's singleton class. Since all classes share the same base class, this means all models end up sharing the same `human_#{collection_name}` methods.

## Solution

This PR changes self.class.send :define_method to define_singleton_method, which correctly defines the method on the model's singleton class:

```ruby
def _define_class_method(enum_name, values)
  ...

  define_singleton_method "human_#{collection_name}" do
    values.to_h { |key, _| [key.to_sym, _translate_enum(enum_name, key)] }
  end
end
```

With this change, each model class will have its own human_#{collection_name} method, ensuring that translations are correctly scoped to each model.

## Testing

Added tests to verify that multiple models with the same enum name have their own distinct `human_#{collection_name}` methods.